### PR TITLE
Differentiate between JSON serialize and Deno runtime errors

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,7 +24,7 @@ This library is in early development, with a basic but powerful API. The API may
 The _Hello World_ example -- print something using JavaScript -- is one line, as it should be:
 ```rust
 fn main() {
-    js_sandbox::eval_json("console.log('Hello Rust from JS')").expect("JS runs");
+	js_sandbox::eval_json("console.log('Hello Rust from JS')").expect("JS runs");
 }
 ```
 
@@ -36,13 +36,13 @@ A very basic application calls a JavaScript function `sub()` from Rust. It passe
 use js_sandbox::{Script, AnyError};
 
 fn main() -> Result<(), AnyError> {
-    let js_code = "function sub(a, b) { return a - b; }";
-    let mut script = Script::from_string(js_code)?;
+	let js_code = "function sub(a, b) { return a - b; }";
+	let mut script = Script::from_string(js_code)?;
 
-    let result: i32 = script.call("sub", (7, 5))?;
+	let result: i32 = script.call("sub", (7, 5))?;
 
-    assert_eq!(result, 2);
-    Ok(())
+	assert_eq!(result, 2);
+	Ok(())
 }
 ```
 
@@ -54,23 +54,23 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 struct Person {
-    name: String,
-    age: u8,
+	name: String,
+	age: u8,
 }
 
 fn main() -> Result<(), AnyError> {
-    let src = r#"
+	let src = r#"
         function toString(person) {
             return "A person named " + person.name + " of age " + person.age;
         }"#;
 
-    let mut script = Script::from_string(src)?;
+	let mut script = Script::from_string(src)?;
 
-    let person = Person { name: "Roger".to_string(), age: 42 };
-    let result: String = script.call("toString", (person,))?;
+	let person = Person { name: "Roger".to_string(), age: 42 };
+	let result: String = script.call("toString", (person,))?;
 
-    assert_eq!(result, "A person named Roger of age 42");
-    Ok(())
+	assert_eq!(result, "A person named Roger of age 42");
+	Ok(())
 }
 ```
 
@@ -85,14 +85,14 @@ If you want to statically embed UTF-8 encoded files in the Rust binary, you can 
 use js_sandbox::Script;
 
 fn main() {
-    // (1) at runtime:
-    let mut script = Script::from_file("script.js").expect("load + init succeeds");
+	// (1) at runtime:
+	let mut script = Script::from_file("script.js").expect("load + init succeeds");
 
-    // (2) at compile time:
-    let code: &'static str = include_str!("script.js");
-    let mut script = Script::from_string(code).expect("init succeeds");
+	// (2) at compile time:
+	let code: &'static str = include_str!("script.js");
+	let mut script = Script::from_string(code).expect("init succeeds");
 
-    // use script as usual
+	// use script as usual
 }
 ```
 
@@ -105,19 +105,19 @@ This example appends a string in two calls, and then gets the result in a third 
 use js_sandbox::{Script, AnyError};
 
 fn main() -> Result<(), AnyError> {
-    let src = r#"
+	let src = r#"
         var total = '';
         function append(str) { total += str; }
         function get()       { return total; }"#;
 
-    let mut script = Script::from_string(src)?;
+	let mut script = Script::from_string(src)?;
 
-    let _: () = script.call("append", ("hello",))?;
-    let _: () = script.call("append", (" world",))?;
-    let result: String = script.call("get", ())?;
+	let _: () = script.call("append", ("hello",))?;
+	let _: () = script.call("append", (" world",))?;
+	let result: String = script.call("get", ())?;
 
-    assert_eq!(result, "hello world");
-    Ok(())
+	assert_eq!(result, "hello world");
+	Ok(())
 }
 ```
 
@@ -130,19 +130,19 @@ a timeout, after which JavaScript execution is aborted.
 use js_sandbox::{Script, JsError};
 
 fn main() -> Result<(), JsError> {
-    use std::time::Duration;
-    let js_code = "function run_forever() { for(;;) {} }";
-    let mut script = Script::from_string(js_code)?
-        .with_timeout(Duration::from_millis(1000));
+	use std::time::Duration;
+	let js_code = "function run_forever() { for(;;) {} }";
+	let mut script = Script::from_string(js_code)?
+		.with_timeout(Duration::from_millis(1000));
 
-    let result: Result<String, JsError> = script.call("run_forever", ());
+	let result: Result<String, JsError> = script.call("run_forever", ());
 
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "Uncaught Error: execution terminated".to_string()
-    );
+	assert_eq!(
+		result.unwrap_err().to_string(),
+		"Uncaught Error: execution terminated".to_string()
+	);
 
-    Ok(())
+	Ok(())
 }
 ```
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -24,7 +24,7 @@ This library is in early development, with a basic but powerful API. The API may
 The _Hello World_ example -- print something using JavaScript -- is one line, as it should be:
 ```rust
 fn main() {
-	js_sandbox::eval_json("console.log('Hello Rust from JS')").expect("JS runs");
+    js_sandbox::eval_json("console.log('Hello Rust from JS')").expect("JS runs");
 }
 ```
 
@@ -36,13 +36,13 @@ A very basic application calls a JavaScript function `sub()` from Rust. It passe
 use js_sandbox::{Script, AnyError};
 
 fn main() -> Result<(), AnyError> {
-	let js_code = "function sub(a, b) { return a - b; }";
-	let mut script = Script::from_string(js_code)?;
+    let js_code = "function sub(a, b) { return a - b; }";
+    let mut script = Script::from_string(js_code)?;
 
-	let result: i32 = script.call("sub", (7, 5))?;
+    let result: i32 = script.call("sub", (7, 5))?;
 
-	assert_eq!(result, 2);
-	Ok(())
+    assert_eq!(result, 2);
+    Ok(())
 }
 ```
 
@@ -54,23 +54,23 @@ use serde::Serialize;
 
 #[derive(Serialize)]
 struct Person {
-	name: String,
-	age: u8,
+    name: String,
+    age: u8,
 }
 
 fn main() -> Result<(), AnyError> {
-	let src = r#"
+    let src = r#"
         function toString(person) {
             return "A person named " + person.name + " of age " + person.age;
         }"#;
 
-	let mut script = Script::from_string(src)?;
+    let mut script = Script::from_string(src)?;
 
-	let person = Person { name: "Roger".to_string(), age: 42 };
-	let result: String = script.call("toString", (person,))?;
+    let person = Person { name: "Roger".to_string(), age: 42 };
+    let result: String = script.call("toString", (person,))?;
 
-	assert_eq!(result, "A person named Roger of age 42");
-	Ok(())
+    assert_eq!(result, "A person named Roger of age 42");
+    Ok(())
 }
 ```
 
@@ -85,14 +85,14 @@ If you want to statically embed UTF-8 encoded files in the Rust binary, you can 
 use js_sandbox::Script;
 
 fn main() {
-	// (1) at runtime:
-	let mut script = Script::from_file("script.js").expect("load + init succeeds");
+    // (1) at runtime:
+    let mut script = Script::from_file("script.js").expect("load + init succeeds");
 
-	// (2) at compile time:
-	let code: &'static str = include_str!("script.js");
-	let mut script = Script::from_string(code).expect("init succeeds");
+    // (2) at compile time:
+    let code: &'static str = include_str!("script.js");
+    let mut script = Script::from_string(code).expect("init succeeds");
 
-	// use script as usual
+    // use script as usual
 }
 ```
 
@@ -105,19 +105,19 @@ This example appends a string in two calls, and then gets the result in a third 
 use js_sandbox::{Script, AnyError};
 
 fn main() -> Result<(), AnyError> {
-	let src = r#"
+    let src = r#"
         var total = '';
         function append(str) { total += str; }
         function get()       { return total; }"#;
 
-	let mut script = Script::from_string(src)?;
+    let mut script = Script::from_string(src)?;
 
-	let _: () = script.call("append", ("hello",))?;
-	let _: () = script.call("append", (" world",))?;
-	let result: String = script.call("get", ())?;
+    let _: () = script.call("append", ("hello",))?;
+    let _: () = script.call("append", (" world",))?;
+    let result: String = script.call("get", ())?;
 
-	assert_eq!(result, "hello world");
-	Ok(())
+    assert_eq!(result, "hello world");
+    Ok(())
 }
 ```
 
@@ -127,22 +127,22 @@ The JS code may contain long- or forever-running loops that block Rust code. It 
 a timeout, after which JavaScript execution is aborted.
 
 ```rust
-use js_sandbox::{Script, JsError};
+use js_sandbox::{Script, AnyError};
 
-fn main() -> Result<(), JsError> {
-	use std::time::Duration;
-	let js_code = "function run_forever() { for(;;) {} }";
-	let mut script = Script::from_string(js_code)?
-		.with_timeout(Duration::from_millis(1000));
+fn main() -> Result<(), AnyError> {
+    use std::time::Duration;
+    let js_code = "function run_forever() { for(;;) {} }";
+    let mut script = Script::from_string(js_code)?
+        .with_timeout(Duration::from_millis(1000));
 
-	let result: Result<String, JsError> = script.call("run_forever", ());
+    let result: Result<String, AnyError> = script.call("run_forever", ());
 
-	assert_eq!(
-		result.unwrap_err().to_string(),
-		"Uncaught Error: execution terminated".to_string()
-	);
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Uncaught Error: execution terminated".to_string()
+    );
 
-	Ok(())
+    Ok(())
 }
 ```
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -127,15 +127,15 @@ The JS code may contain long- or forever-running loops that block Rust code. It 
 a timeout, after which JavaScript execution is aborted.
 
 ```rust
-use js_sandbox::{Script, AnyError};
+use js_sandbox::{Script, JsError};
 
-fn main() -> Result<(), AnyError> {
+fn main() -> Result<(), JsError> {
     use std::time::Duration;
     let js_code = "function run_forever() { for(;;) {} }";
     let mut script = Script::from_string(js_code)?
         .with_timeout(Duration::from_millis(1000));
 
-    let result: Result<String, AnyError> = script.call("run_forever", ());
+    let result: Result<String, JsError> = script.call("run_forever", ());
 
     assert_eq!(
         result.unwrap_err().to_string(),

--- a/js-sandbox/src/call_args.rs
+++ b/js-sandbox/src/call_args.rs
@@ -3,36 +3,20 @@
 use crate::AnyError;
 use serde::Serialize;
 
-mod sealed {
-	use super::*;
-
-	pub trait Sealed {}
-	impl Sealed for () {}
-
-	macro_rules! impl_sealed {
-		($($param:ident),+) => {
-			#[allow(non_snake_case)] // use generic params as variable names
-			impl<$($param),+> Sealed for ($($param),+,)
-				where $($param : Serialize),+
-			{ }
-		}
-	}
-
-	impl_sealed!(P0);
-	impl_sealed!(P0, P1);
-	impl_sealed!(P0, P1, P2);
-	impl_sealed!(P0, P1, P2, P3);
-	impl_sealed!(P0, P1, P2, P3, P4);
+/// Method sealing token
+mod private {
+    pub trait Sealed {}
 }
 
 /// Trait that is implemented for types that can be passed as argument to `Script::call()`.
 ///
 /// This is currently only implemented for tuples of size 0..=5, i.e. JS functions with 0 to 5 arguments.
 /// Use structs or arrays inside a one-element tuple if you need more flexibility.
-pub trait CallArgs: sealed::Sealed {
+pub trait CallArgs : private::Sealed {
 	fn into_arg_string(self) -> Result<String, AnyError>;
 }
 
+impl private::Sealed for () {}
 impl CallArgs for () {
 	fn into_arg_string(self) -> Result<String, AnyError> {
 		Ok(String::new())
@@ -41,6 +25,9 @@ impl CallArgs for () {
 
 macro_rules! impl_call_args {
 	($($param:ident),+) => {
+		#[allow(non_snake_case)]
+		impl<$($param),+> private::Sealed for ($($param),+,) {}
+		
 		#[allow(non_snake_case)] // use generic params as variable names
 		impl<$($param),+> CallArgs for ($($param),+,)
 			where $($param : Serialize),+

--- a/js-sandbox/src/call_args.rs
+++ b/js-sandbox/src/call_args.rs
@@ -3,11 +3,33 @@
 use crate::AnyError;
 use serde::Serialize;
 
+mod sealed {
+	use super::*;
+
+	pub trait Sealed {}
+	impl Sealed for () {}
+
+	macro_rules! impl_sealed {
+		($($param:ident),+) => {
+			#[allow(non_snake_case)] // use generic params as variable names
+			impl<$($param),+> Sealed for ($($param),+,)
+				where $($param : Serialize),+
+			{ }
+		}
+	}
+
+	impl_sealed!(P0);
+	impl_sealed!(P0, P1);
+	impl_sealed!(P0, P1, P2);
+	impl_sealed!(P0, P1, P2, P3);
+	impl_sealed!(P0, P1, P2, P3, P4);
+}
+
 /// Trait that is implemented for types that can be passed as argument to `Script::call()`.
 ///
 /// This is currently only implemented for tuples of size 0..=5, i.e. JS functions with 0 to 5 arguments.
 /// Use structs or arrays inside a one-element tuple if you need more flexibility.
-pub trait CallArgs {
+pub trait CallArgs: sealed::Sealed {
 	fn into_arg_string(self) -> Result<String, AnyError>;
 }
 

--- a/js-sandbox/src/call_args.rs
+++ b/js-sandbox/src/call_args.rs
@@ -13,6 +13,7 @@ mod private {
 /// This is currently only implemented for tuples of size 0..=5, i.e. JS functions with 0 to 5 arguments.
 /// Use structs or arrays inside a one-element tuple if you need more flexibility.
 pub trait CallArgs: private::Sealed {
+	/// Convert the arguments into a JSON string
 	fn into_arg_string(self) -> Result<String, AnyError>;
 }
 

--- a/js-sandbox/src/call_args.rs
+++ b/js-sandbox/src/call_args.rs
@@ -3,16 +3,16 @@
 use crate::AnyError;
 use serde::Serialize;
 
-/// Method sealing token
+/// Sealing token
 mod private {
-    pub trait Sealed {}
+	pub trait Sealed {}
 }
 
 /// Trait that is implemented for types that can be passed as argument to `Script::call()`.
 ///
 /// This is currently only implemented for tuples of size 0..=5, i.e. JS functions with 0 to 5 arguments.
 /// Use structs or arrays inside a one-element tuple if you need more flexibility.
-pub trait CallArgs : private::Sealed {
+pub trait CallArgs: private::Sealed {
 	fn into_arg_string(self) -> Result<String, AnyError>;
 }
 
@@ -27,7 +27,7 @@ macro_rules! impl_call_args {
 	($($param:ident),+) => {
 		#[allow(non_snake_case)]
 		impl<$($param),+> private::Sealed for ($($param),+,) {}
-		
+
 		#[allow(non_snake_case)] // use generic params as variable names
 		impl<$($param),+> CallArgs for ($($param),+,)
 			where $($param : Serialize),+

--- a/js-sandbox/src/js_error.rs
+++ b/js-sandbox/src/js_error.rs
@@ -1,0 +1,36 @@
+use std::{
+	error::Error,
+	fmt::{self, Display},
+};
+
+use crate::AnyError;
+
+/// Represents an error ocurring during script execution
+#[derive(Debug)]
+pub enum JsError {
+	Json(serde_json::Error),
+	Runtime(AnyError),
+}
+
+impl Error for JsError {}
+
+impl Display for JsError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			JsError::Json(e) => write!(f, "{}", e),
+			JsError::Runtime(e) => write!(f, "{}", e),
+		}
+	}
+}
+
+impl From<AnyError> for JsError {
+	fn from(e: AnyError) -> JsError {
+		JsError::Runtime(e)
+	}
+}
+
+impl From<serde_json::Error> for JsError {
+	fn from(e: serde_json::Error) -> JsError {
+		JsError::Json(e)
+	}
+}

--- a/js-sandbox/src/js_error.rs
+++ b/js-sandbox/src/js_error.rs
@@ -8,7 +8,10 @@ use crate::AnyError;
 /// Represents an error ocurring during script execution
 #[derive(Debug)]
 pub enum JsError {
+	/// JSON errors stemming from arguments or return values
 	Json(serde_json::Error),
+
+	/// Runtime errors occuring within a JS script
 	Runtime(AnyError),
 }
 

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -150,6 +150,7 @@
 //!
 //! [Deno]: https://deno.land
 //! [serde_json]: https://docs.serde.rs/serde_json
+#![warn(missing_docs)]
 
 pub use call_args::CallArgs;
 pub use js_sandbox_macros::js_api;
@@ -170,6 +171,7 @@ pub use js_error::JsError;
 // use through deno_core, to make sure same version of anyhow crate is used
 pub type AnyError = deno_core::error::AnyError;
 
+/// Wrapper type representing a result that can result in a JS runtime error
 pub type JsResult<T> = Result<T, JsError>;
 
 mod call_args;

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -150,7 +150,6 @@
 //!
 //! [Deno]: https://deno.land
 //! [serde_json]: https://docs.serde.rs/serde_json
-#![warn(missing_docs)]
 
 pub use call_args::CallArgs;
 pub use js_sandbox_macros::js_api;

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -151,10 +151,10 @@
 //! [Deno]: https://deno.land
 //! [serde_json]: https://docs.serde.rs/serde_json
 
+pub use call_args::CallArgs;
 pub use js_sandbox_macros::js_api;
 pub use script::*;
 pub use util::eval_json;
-pub use call_args::CallArgs;
 
 /// Represents a value passed to or from JavaScript.
 ///

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -161,14 +161,18 @@ pub use util::eval_json;
 /// Currently aliased as serde_json's Value type.
 pub type JsValue = serde_json::Value;
 
+/// Error occuring during script execution
+pub use js_error::JsError;
+
 /// Polymorphic error type able to represent different error domains.
 ///
 /// Currently reusing [anyhow::Error](../anyhow/enum.Error.html), this type may change slightly in the future depending on js-sandbox's needs.
 // use through deno_core, to make sure same version of anyhow crate is used
 pub type AnyError = deno_core::error::AnyError;
 
-pub type JsResult<T> = Result<T, AnyError>;
+pub type JsResult<T> = Result<T, JsError>;
 
 mod call_args;
+mod js_error;
 mod script;
 mod util;

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -129,15 +129,15 @@
 //! a timeout, after which JavaScript execution is aborted.
 //!
 //! ```rust
-//! use js_sandbox::{Script, AnyError};
+//! use js_sandbox::{Script, JsError};
 //!
-//! fn main() -> Result<(), AnyError> {
+//! fn main() -> Result<(), JsError> {
 //! 	use std::time::Duration;
 //! 	let js_code = "function run_forever() { for(;;) {} }";
 //! 	let mut script = Script::from_string(js_code)?
 //! 		.with_timeout(Duration::from_millis(1000));
 //!
-//! 	let result: Result<String, AnyError> = script.call("run_forever", ());
+//! 	let result: Result<String, JsError> = script.call("run_forever", ());
 //!
 //! 	assert_eq!(
 //! 		result.unwrap_err().to_string(),

--- a/js-sandbox/src/lib.rs
+++ b/js-sandbox/src/lib.rs
@@ -154,6 +154,7 @@
 pub use js_sandbox_macros::js_api;
 pub use script::*;
 pub use util::eval_json;
+pub use call_args::CallArgs;
 
 /// Represents a value passed to or from JavaScript.
 ///

--- a/js-sandbox/src/script.rs
+++ b/js-sandbox/src/script.rs
@@ -10,7 +10,6 @@ use serde::de::DeserializeOwned;
 
 use crate::{AnyError, CallArgs, JsError, JsValue};
 
-/// Trait denoting a JS API
 pub trait JsApi<'a> {
 	/// Generate an API from a script
 	fn from_script(script: &'a mut Script) -> Self
@@ -103,7 +102,6 @@ impl Script {
 		Ok(result)
 	}
 
-	/// Bind this script to an API
 	pub fn bind_api<'a, A>(&'a mut self) -> A
 	where
 		A: JsApi<'a>,

--- a/js-sandbox/src/script.rs
+++ b/js-sandbox/src/script.rs
@@ -8,8 +8,7 @@ use std::{thread, time::Duration};
 use deno_core::{op, Extension, JsRuntime, OpState, ZeroCopyBuf};
 use serde::de::DeserializeOwned;
 
-use crate::call_args::CallArgs;
-use crate::{AnyError, JsValue};
+use crate::{AnyError, CallArgs, JsError, JsValue};
 
 pub trait JsApi<'a> {
 	fn from_script(script: &'a mut Script) -> Self
@@ -36,7 +35,7 @@ impl Script {
 	/// Initialize a script with the given JavaScript source code.
 	///
 	/// Returns a new object on success, and an error in case of syntax or initialization error with the code.
-	pub fn from_string(js_code: &str) -> Result<Self, AnyError> {
+	pub fn from_string(js_code: &str) -> Result<Self, JsError> {
 		// console.log() is not available by default -- add the most basic version with single argument (and no warn/info/... variants)
 		let all_code =
 			"const console = { log: function(expr) { Deno.core.print(expr + '\\n', false); } };"
@@ -51,7 +50,7 @@ impl Script {
 	/// At the moment, a script is limited to a single file, and you will need to do bundling yourself (e.g. with `esbuild`).
 	///
 	/// Returns a new object on success. Fails if the file cannot be opened or in case of syntax or initialization error with the code.
-	pub fn from_file(file: impl AsRef<Path>) -> Result<Self, AnyError> {
+	pub fn from_file(file: impl AsRef<Path>) -> Result<Self, JsError> {
 		// let filename = file
 		// 	.as_ref()
 		// 	.file_name()
@@ -61,7 +60,7 @@ impl Script {
 
 		match std::fs::read_to_string(file) {
 			Ok(js_code) => Self::create_script(js_code),
-			Err(e) => Err(AnyError::from(e)),
+			Err(e) => Err(JsError::Runtime(AnyError::from(e))),
 		}
 	}
 
@@ -90,7 +89,7 @@ impl Script {
 	/// `args_tuple` needs to be a tuple.
 	///
 	/// Each tuple element is converted to JSON (using serde_json) and passed as a distinct argument to the JS function.
-	pub fn call<A, R>(&mut self, fn_name: &str, args_tuple: A) -> Result<R, AnyError>
+	pub fn call<A, R>(&mut self, fn_name: &str, args_tuple: A) -> Result<R, JsError>
 	where
 		A: CallArgs,
 		R: DeserializeOwned,
@@ -109,11 +108,11 @@ impl Script {
 		A::from_script(self)
 	}
 
-	pub(crate) fn call_json(&mut self, fn_name: &str, args: &JsValue) -> Result<JsValue, AnyError> {
+	pub(crate) fn call_json(&mut self, fn_name: &str, args: &JsValue) -> Result<JsValue, JsError> {
 		self.call_impl(fn_name, args.to_string())
 	}
 
-	fn call_impl(&mut self, fn_name: &str, json_args: String) -> Result<JsValue, AnyError> {
+	fn call_impl(&mut self, fn_name: &str, json_args: String) -> Result<JsValue, JsError> {
 		// Note: ops() is required to initialize internal state
 		// Wrap everything in scoped block
 
@@ -163,7 +162,7 @@ impl Script {
 		Ok(extracted.json_value)
 	}
 
-	fn create_script(js_code: String) -> Result<Self, AnyError> {
+	fn create_script(js_code: String) -> Result<Self, JsError> {
 		let ext = Extension::builder("script")
 			.ops(vec![(op_return::decl())])
 			.build();

--- a/js-sandbox/src/script.rs
+++ b/js-sandbox/src/script.rs
@@ -10,7 +10,9 @@ use serde::de::DeserializeOwned;
 
 use crate::{AnyError, CallArgs, JsError, JsValue};
 
+/// Trait denoting a JS API
 pub trait JsApi<'a> {
+	/// Generate an API from a script
 	fn from_script(script: &'a mut Script) -> Self
 	where
 		Self: Sized;
@@ -101,6 +103,7 @@ impl Script {
 		Ok(result)
 	}
 
+	/// Bind this script to an API
 	pub fn bind_api<'a, A>(&'a mut self) -> A
 	where
 		A: JsApi<'a>,

--- a/js-sandbox/src/util.rs
+++ b/js-sandbox/src/util.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2020-2023 js-sandbox contributors. Zlib license.
 
-use crate::{AnyError, JsValue, Script};
+use crate::{JsError, JsValue, Script};
 
 /// Evaluates a standalone Javascript expression, and returns the result as a JSON value.
 ///
 /// If there is an error, Err will be returned.
 /// This function is primarily useful for small standalone experiments. Usually, you would want to use the [`Script`](struct.Script.html) struct
 /// for more sophisticated Rust->JS interaction.
-pub fn eval_json(js_expr: &str) -> Result<JsValue, AnyError> {
+pub fn eval_json(js_expr: &str) -> Result<JsValue, JsError> {
 	let code = format!(
 		"
 		function __rust_expr() {{

--- a/js-sandbox/tests/test_script.rs
+++ b/js-sandbox/tests/test_script.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
-use js_sandbox::{AnyError, Script};
+use js_sandbox::{AnyError, JsError, Script};
 use util::expect_error;
 
 mod util;
@@ -195,7 +195,7 @@ fn call_error_inexistent_function() {
 	let mut script = Script::from_string(src).expect("Initialization succeeds");
 
 	let args = 7;
-	let result: Result<i32, AnyError> = script.call("tripel", (args,));
+	let result: Result<i32, JsError> = script.call("tripel", (args,));
 
 	expect_error(result, "Inexistent function");
 }
@@ -206,7 +206,7 @@ fn call_error_exception() {
 	let mut script = Script::from_string(src).expect("Initialization succeeds");
 
 	let args = 7;
-	let result: Result<i32, AnyError> = script.call("triple", (args,));
+	let result: Result<i32, JsError> = script.call("triple", (args,));
 
 	expect_error(result, "Runtime exception");
 }
@@ -222,7 +222,7 @@ fn call_error_timeout() {
 		.with_timeout(timeout);
 
 	let start = Instant::now();
-	let result: Result<String, AnyError> = script.call("run_forever", ());
+	let result: Result<String, JsError> = script.call("run_forever", ());
 	let duration = start.elapsed();
 
 	expect_error(result, "Timed out");

--- a/js-sandbox/tests/util.rs
+++ b/js-sandbox/tests/util.rs
@@ -1,20 +1,17 @@
 // Copyright (c) 2020-2023 js-sandbox contributors. Zlib license.
 
-use deno_core::error::JsError;
+use js_sandbox::JsError;
 
-use js_sandbox::AnyError;
-
-pub fn expect_error<T>(result: Result<T, AnyError>, error_type: &str) {
+pub fn expect_error<T>(result: Result<T, JsError>, error_type: &str) {
 	let err = match result {
 		Ok(_) => panic!("Call with {error_type} must not succeed"),
 		Err(e) => e,
 	};
 
-	let err = err
-		.downcast_ref::<JsError>()
-		.unwrap_or_else(|| panic!("{error_type} must lead to JsError type"));
-
-	let msg = err.message.clone().unwrap_or(String::from("unknown"));
-
-	println!("Expected error occurred:\n{msg}");
+	if let JsError::Runtime(e) = err {
+		let err = e
+			.downcast_ref::<JsError>()
+			.unwrap_or_else(|| panic!("{error_type} must lead to JsError type"));
+		println!("Expected error occurred:\n{err}");
+	}
 }

--- a/js-sandbox/tests/util.rs
+++ b/js-sandbox/tests/util.rs
@@ -10,8 +10,8 @@ pub fn expect_error<T>(result: Result<T, JsError>, error_type: &str) {
 
 	if let JsError::Runtime(e) = err {
 		let err = e
-			.downcast_ref::<JsError>()
-			.unwrap_or_else(|| panic!("{error_type} must lead to JsError type"));
+			.downcast_ref::<deno_core::error::JsError>()
+			.unwrap_or_else(|| panic!("{error_type} must lead to deno_core::error::JsError type"));
 		println!("Expected error occurred:\n{err}");
 	}
 }


### PR DESCRIPTION
Wanted to expose the CallArgs trait so I can wrap Script::call to return a serde_json::Value instead, to avoid a panic on the JS function returning the wrong type.