### PR TITLE
Fix sandbox bypass via dynamic import

### DIFF
--- a/js-sandbox/src/script.rs
+++ b/js-sandbox/src/script.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::rc::Rc;
 use std::{thread, time::Duration};
 
-use deno_core::{serde_v8, v8, FastString, JsRuntime};
+use deno_core::{serde_v8, v8, FastString, JsRuntime, ModuleLoader, NoopModuleLoader};
 use serde::de::DeserializeOwned;
 
 use crate::{CallArgs, JsError, JsValue};
@@ -34,8 +34,11 @@ impl Script {
 	/// Initialize a script with the given JavaScript source code.
 	///
 	/// Returns a new object on success, and an error in case of syntax or initialization error with the code.
+	///
+	/// The script runs with a deny-all module loader: dynamic `import(...)` from JavaScript is rejected.
+	/// Use [`Self::from_string_with_loader()`] to provide a custom [`ModuleLoader`].
 	pub fn from_string(js_code: &str) -> Result<Self, JsError> {
-		Self::create_script(js_code.to_string())
+		Self::create_script(js_code.to_string(), Rc::new(NoopModuleLoader))
 	}
 
 	/// Initialize a script by loading it from a .js file.
@@ -44,11 +47,29 @@ impl Script {
 	/// At the moment, a script is limited to a single file, and you will need to do bundling yourself (e.g. with `esbuild`).
 	///
 	/// Returns a new object on success. Fails if the file cannot be opened or in case of syntax or initialization error with the code.
+	///
+	/// As with [`Self::from_string()`], dynamic `import(...)` from JavaScript is rejected.
 	pub fn from_file(file: impl AsRef<Path>) -> Result<Self, JsError> {
 		match std::fs::read_to_string(file) {
-			Ok(js_code) => Self::create_script(js_code),
+			Ok(js_code) => Self::create_script(js_code, Rc::new(NoopModuleLoader)),
 			Err(e) => Err(JsError::from(e)),
 		}
+	}
+
+	/// Initialize a script with a custom [`ModuleLoader`], enabling JavaScript `import(...)`.
+	///
+	/// # Security
+	/// The default constructors deliberately reject all dynamic imports, because `deno_core`'s built-in
+	/// [`deno_core::FsModuleLoader`] reads arbitrary host files and exposes them to JS via import attributes
+	/// such as `{ with: { type: "text" } }`, fully bypassing the sandbox.
+	///
+	/// Passing a loader here re-enables that mechanism. The caller is responsible for ensuring the loader
+	/// only resolves trusted specifiers. **Do not pass `FsModuleLoader` if the JS code is untrusted.**
+	pub fn from_string_with_loader(
+		js_code: &str,
+		module_loader: Rc<dyn ModuleLoader>,
+	) -> Result<Self, JsError> {
+		Self::create_script(js_code.to_string(), module_loader)
 	}
 
 	/// Equips this script with a timeout, meaning that any function call is aborted after the specified duration.
@@ -129,12 +150,12 @@ impl Script {
 		Ok(value)
 	}
 
-	fn create_script<S>(js_code: S) -> Result<Self, JsError>
+	fn create_script<S>(js_code: S, module_loader: Rc<dyn ModuleLoader>) -> Result<Self, JsError>
 	where
 		S: Into<FastString>,
 	{
 		let mut runtime = JsRuntime::new(deno_core::RuntimeOptions {
-			module_loader: Some(Rc::new(deno_core::FsModuleLoader)),
+			module_loader: Some(module_loader),
 			..Default::default()
 		});
 

--- a/js-sandbox/tests/test_script.rs
+++ b/js-sandbox/tests/test_script.rs
@@ -253,3 +253,55 @@ fn call_async() {
 
 	assert_eq!(result, 3);
 }
+
+// Regression test for sandbox bypass via `deno_core::FsModuleLoader` (issue #32).
+//
+// Before the fix, `await import("file:///...", { with: { type: "text" } })` resolved through the default FS loader and
+// exfiltrated host file contents to attacker-controlled JS. The default constructors must reject dynamic imports.
+#[test]
+fn dynamic_import_is_blocked() {
+	use std::io::Write;
+
+	struct TempFile(std::path::PathBuf);
+	impl Drop for TempFile {
+		fn drop(&mut self) {
+			let _ = std::fs::remove_file(&self.0);
+		}
+	}
+
+	// Create a host file with secret contents in the OS temp dir.
+	// Wrapped in a Drop guard so the file is removed even if an assertion below panics.
+	let mut path = std::env::temp_dir();
+	path.push("js-sandbox-test-secret.txt");
+	{
+		let mut f = std::fs::File::create(&path).expect("create secret file");
+		f.write_all(b"TOP_SECRET_VALUE").expect("write secret");
+	}
+	let _guard = TempFile(path.clone());
+	let url = format!("file://{}", path.display());
+
+	let js_code = format!(
+		r#"
+		async function exfiltrator() {{
+			const mod = await import("{url}", {{ with: {{ type: "text" }} }});
+			return mod.default;
+		}}
+		"#
+	);
+
+	let mut script = Script::from_string(&js_code).expect("init succeeds");
+	let result: Result<String, JsError> = script.call("exfiltrator", ());
+
+	let err = match result {
+		Ok(leaked) => {
+			panic!("Sandbox bypass: dynamic import returned host file contents: {leaked:?}")
+		}
+		Err(e) => e,
+	};
+
+	let msg = err.to_string();
+	assert!(
+		!msg.contains("TOP_SECRET_VALUE"),
+		"Error message must not leak file contents: {msg}"
+	);
+}


### PR DESCRIPTION
Attempts to fix #35.

Previously, `Script` was constructed with `deno_core::FsModuleLoader`, which reads arbitrary host files. Untrusted JS could exfiltrate file contents (e.g. secrets) through dynamic import attributes.

The default loader is now `NoopModuleLoader`, which rejects dynamic `import(...)` statements. Existing `Script::from_string()` and `from_file()` users see no API change; attempts to dynamically import from JS now error instead of leaking host data.

For callers who legitimately need module loading, a new `Script::from_string_with_loader()` accepts a custom module loader.

---

I added a regression test that fails on `master` and passes now.

Many thanks to Sam Sanoop (@snoopysecurity) for reporting.